### PR TITLE
Add Windows version guards around MFVideoFormat GUIDs.

### DIFF
--- a/src/cl_mf_handler.cc
+++ b/src/cl_mf_handler.cc
@@ -441,12 +441,16 @@ mf_handler::s_fmt (std::string fmtstr, uint32_t xres, uint32_t yres)
       // mapping to different FourCC
       if (fmtstr == "YUYV")
         hr = type->SetGUID (MF_MT_SUBTYPE, MFVideoFormat_YUY2);
+#if WDK_NTDDI_VERSION >= NTDDI_WIN10_RS3
       else if (fmtstr == "AV01")
         hr = type->SetGUID (MF_MT_SUBTYPE, MFVideoFormat_AV1);
+#endif
       else if (fmtstr == "HEVS")
         hr = type->SetGUID (MF_MT_SUBTYPE, MFVideoFormat_HEVC_ES);
+#if NTDDI_VERSION >= NTDDI_WIN10_FE
       else if (fmtstr == "theo")
         hr = type->SetGUID (MF_MT_SUBTYPE, MFVideoFormat_Theora);
+#endif
       else if (fmtstr == "dvc ")
         hr = type->SetGUID (MF_MT_SUBTYPE, MFVideoFormat_DVC);
       else


### PR DESCRIPTION
Some MFVideoFormat GUIDs are only available in newer Windows versions. Add preprocessor guards around these GUIDs to avoid a compilation error in case the targeted Windows version is too old.

Use the same preprocessor conditions that MinGW-w64 uses in their headers.
