### PR TITLE
getsnapshot.m: Tolerate only unknown video format in test.

### DIFF
--- a/inst/@videoinput/getsnapshot.m
+++ b/inst/@videoinput/getsnapshot.m
@@ -122,7 +122,11 @@ endfunction
 %!   try
 %!     img = getsnapshot (obj);
 %!     assert (size (img), [fliplr(s) 3]);
-%!   catch
+%!   catch ME
+%!     if (! strcmp (ME.identifier, 'image-acquisition:getsnapshot:unsupported-video-format'))
+%!       stop (obj);
+%!       rethrow (ME);
+%!     endif
 %!   end_try_catch
 %!   # getting a raw representation (like for H264) should always work
 %!   img = getsnapshot (obj, false, true); # ret raw

--- a/src/cl_mf_handler.cc
+++ b/src/cl_mf_handler.cc
@@ -898,7 +898,9 @@ octave_value_list mf_handler::capture (int nargout, bool preview, bool raw_outpu
       else if (is_mjpg)
         rgb_img = JPG_to_RGB (ret(0));
       else
-        error ("mf_handler::capture: no conversion from '%s' to RGB3 implemented yet, please try another VideoFormat or use RAW = true.", fmt.c_str());
+        error_with_id ("image-acquisition:getsnapshot:unsupported-video-format",
+          "mf_handler::capture: no conversion from '%s' to RGB3 implemented yet, please try another VideoFormat or use RAW = true.",
+          fmt.c_str());
 
       if (preview)
         {


### PR DESCRIPTION
Emit the error for an unsupported video format with an id, and check for that specific id in the self test.

That's not really necessary. But it might help to catch errors that aren't "expected".
