### PR TITLE
configure.ac: Let Octave pkg installer override mkoctfile

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -9,14 +9,14 @@ AC_CONFIG_HEADERS([config.h])
 AC_PROG_CXX
 AC_LANG(C++)
 
-AC_CHECK_PROG([HAVE_MKOCTFILE], [mkoctfile], [yes], [no])
-if [test $HAVE_MKOCTFILE = "no"]; then
+AC_CHECK_PROG(MKOCTFILE, mkoctfile, mkoctfile)
+if test -z "$MKOCTFILE"; then
   AC_MSG_ERROR([mkoctfile required to install $PACKAGE_NAME])
 fi
 
 AC_PATH_PROG([FLTK_CONFIG], [fltk-config], [no])
 
-if [test $FLTK_CONFIG = "no"]; then
+if test $FLTK_CONFIG = "no"; then
   AC_MSG_ERROR([fltk-config required to install $PACKAGE_NAME])
 else
   LIBS="`$FLTK_CONFIG --ldflags` $LIBS"


### PR DESCRIPTION
Change the test in the configure script to check for the executable that is going to be used by the Makefile.
(See 5f9bf9bae860ab9ea0865980265aea6dac8d4591 for the corresponding change in the Makefile.)

Remove unnecessary m4 grouping in if condition.

This change should help to address the (random) build error that we are seeing on the MXE Octave buildbots.
If the `build-octave` target (that is building a Linux-native Octave) happens to be built before the image-acquisition package, the `configure` script succeeds to detect a `mkoctfile` executable. But that executable won't be used by the `Makefile` in that cross-build configuration.
If the `build-octave` target happens to not be built yet, that `configure` test fails. (See https://octave.discourse.group/t/any-remaining-blockers-before-making-a-10-2-release/6459/30.)
In either case, the result of that test isn't quite correct.

With this change, the configure script will test whether it can find the version of `mkoctfile` that will actually be used by the `Makefile` rules. For MXE Octave, that is the prefixed version that cross-builds for a Windows target.

For the `configure.ac` file, this is only a couple of changed lines. The change that we'd need for the generated `configure` script is more complicated.
Would you consider making a new release in case you accept this change? Maybe, you could also include the `configure.ac` file in the tarball?
If the `configure.ac` file had been part of the released tarball, we could probably have applied the change from this PR in MXE Octave and regenerated the `configure` script with `autoreconf -fi`.
We can probably still add the modified `configure.ac` file with a patch now and regenerate the `configure` script with that in MXE Octave. But I'd prefer to use an updated tarball if releasing again is ok for you.

What do you think?